### PR TITLE
Async cover loading from URL, Elapsed time support, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ function onDeviceReady() {
   title = "One More Time";
   album = "Discovery";
   image = "path_within_documents_storage";
-  elapsedTime = my_media.getDuration();
+  duration = my_media.getDuration();
+  elapsedTime = my_media.getElapsedTime();
 
-  var params = [artist, title, album, image,  elapsedTime];
-  window.plugins.remoteControls.updateMetas(function(success){
+  var params = [artist, title, album, image, duration, elapsedTime];
+  remoteControls.updateMetas(function(success){
       console.log(success);
   }, function(fail){
       console.log(fail);

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ function onDeviceReady() {
   artist = "Daft Punk";
   title = "One More Time";
   album = "Discovery";
-  image = "path_within_documents_storage";
+  image = "path_within_documents_storage OR url_starting_with_http_or_https";
   duration = my_media.getDuration();
   elapsedTime = my_media.getElapsedTime();
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     <description>iOS  lock-screen remote-controls and display.</description>
 
     <js-module src="www/RemoteControls.js" name="RemoteControls">
-        <clobbers target="window.plugins.remoteControls" />
+        <clobbers target="window.remoteControls" />
     </js-module>
 
     <author>Seth Hillinger, François LASSERRE, Michael GAUTHIER</author>


### PR DESCRIPTION
Loading of a cover from URL (as well as loading from a file from now on) is done in a separate thread asynchronously and non-blocking.
If image is absent then default image named "no-image" will be used instead.
Elapsed time attribute introduced, allowing to be used along with duration.
I propose to change the namespace from window.plugins.remoteControls to just window.remoteControls, which means it can be accessed via simply remoteControls as well.
Readme is updated to include these changes.