### PR TITLE
Add support for relative paths in Library folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ function onDeviceReady() {
   artist = "Daft Punk";
   title = "One More Time";
   album = "Discovery";
-  image = "path_within_documents_storage OR url_starting_with_http_or_https";
+  image = "path_within_documents_storage OR path_within_library_storage OR url_starting_with_http_or_https";
   duration = my_media.getDuration();
   elapsedTime = my_media.getElapsedTime();
 

--- a/src/ios/RemoteControls.m
+++ b/src/ios/RemoteControls.m
@@ -48,10 +48,18 @@ static RemoteControls *remoteControls = nil;
             }
             // cover is relative path to local file
             else {
+                //check the documents directory
                 NSString *basePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
                 NSString *fullPath = [NSString stringWithFormat:@"%@%@", basePath, cover];
                 BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:fullPath];
+                //check the library directory
+                NSString *basePath2 = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+                NSString *fullPath2 = [NSString stringWithFormat:@"%@%@", basePath2, cover];
+                BOOL fileExists2 = [[NSFileManager defaultManager] fileExistsAtPath:fullPath2];
+                //evaluate if either are true
                 if (fileExists) {
+                    image = [UIImage imageNamed:fullPath];
+                } else if (fileExists2) {
                     image = [UIImage imageNamed:fullPath];
                 }
             }

--- a/src/ios/RemoteControls.m
+++ b/src/ios/RemoteControls.m
@@ -61,7 +61,7 @@ static RemoteControls *remoteControls = nil;
                     image = [UIImage imageNamed:fullPath];
                     NSLog(@"Found image in documents");
                 } else if (fileExists2) {
-                    image = [UIImage imageNamed:fullPath];
+                    image = [UIImage imageNamed:fullPath2];
                     NSLog(@"Found image in library");
                 }
             }

--- a/src/ios/RemoteControls.m
+++ b/src/ios/RemoteControls.m
@@ -59,14 +59,17 @@ static RemoteControls *remoteControls = nil;
                 //evaluate if either are true
                 if (fileExists) {
                     image = [UIImage imageNamed:fullPath];
+                    NSLog(@"Found image in documents");
                 } else if (fileExists2) {
                     image = [UIImage imageNamed:fullPath];
+                    NSLog(@"Found image in library");
                 }
             }
         }
         else {
             // default named "no-image"
             image = [UIImage imageNamed:@"no-image"];
+            NSLog(@"No valid image found");
         }
         // check whether image is loaded
         CGImageRef cgref = [image CGImage];


### PR DESCRIPTION
The Library folder is used for persistent storage that you don't want exposed to the user through itunes.  It is common to store things like local image cache here for coverart!

Pull request simply scans for relative paths under Library the same as it does for documents and then uses the file if found.

Also added a couple of lines of logging to indicate to the if the file was found in a relative path to aid in development.