### PR TITLE
Added cordova iOS 4+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,13 @@ Add the plugin much like any other:
 
 `cordova plugin add com.rd11.remote-controls`
 
-#### Modify the MainViewController.m with these functions:
+#### Modify the MainViewController.m to add this function:
 
 ```
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
-    // Do any additional setup after loading the view from its nib.
-    [[RemoteControls remoteControls] setWebView:self.webView];
-}
-
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-    // Turn off remote control event delivery
-    [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
-}
-
 //add this function
 - (void)remoteControlReceivedWithEvent:(UIEvent *)receivedEvent {
-       [[RemoteControls remoteControls] receiveRemoteEvent:receivedEvent];
-   }
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"receivedEvent" object:receivedEvent];
+}
 ```
 
 Then add this below `#import "MainViewController.h"` in `MainViewController.m`

--- a/README.md
+++ b/README.md
@@ -13,26 +13,6 @@ Add the plugin much like any other:
 
 `cordova plugin add com.rd11.remote-controls`
 
-#### Modify the MainViewController.m to add this function:
-
-```
-//add this function
-- (void)remoteControlReceivedWithEvent:(UIEvent *)receivedEvent {
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"receivedEvent" object:receivedEvent];
-}
-```
-
-Then add this below `#import "MainViewController.h"` in `MainViewController.m`
-
-```
-#import "MainViewController.h"
-//import remoteControls
-#import "RemoteControls.h"
-
-@implementation MainViewController
-
-```
-
 ## Supported Platforms
 - iOS
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,8 +22,6 @@
 
     <license>MIT License</license>
 
-    <info>The MediaPlayer.framework should automatically be added, however you also need to add and modify a few functions in the MainViewContrller.m See the example in the README</info>
-
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="RemoteControls">

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,8 @@
         </config-file>
         <header-file src="src/ios/RemoteControls.h" />
         <source-file src="src/ios/RemoteControls.m" />
+        <header-file src="src/ios/MainViewController+RemoteControls.h" />
+        <source-file src="src/ios/MainViewController+RemoteControls.m" />
         <framework src="MediaPlayer.framework" />
     </platform>
 

--- a/src/ios/MainViewController+RemoteControls.h
+++ b/src/ios/MainViewController+RemoteControls.h
@@ -1,0 +1,12 @@
+//
+//  MainViewController+RemoteControls.h
+//
+//  Created by Julio Cesar Sanchez Hernandez on 4/3/16.
+//
+//
+
+#import "MainViewController.h"
+
+@interface MainViewController (RemoteControls)
+
+@end

--- a/src/ios/MainViewController+RemoteControls.m
+++ b/src/ios/MainViewController+RemoteControls.m
@@ -1,0 +1,16 @@
+//
+//  MainViewController+RemoteControls.m
+//
+//  Created by Julio Cesar Sanchez Hernandez on 4/3/16.
+//
+//
+
+#import "MainViewController+RemoteControls.h"
+
+@implementation MainViewController (RemoteControls)
+
+- (void)remoteControlReceivedWithEvent:(UIEvent *)receivedEvent {
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"receivedEvent" object:receivedEvent];
+}
+
+@end

--- a/src/ios/RemoteControls.h
+++ b/src/ios/RemoteControls.h
@@ -15,9 +15,7 @@
 @interface RemoteControls : CDVPlugin {
 }
 
-+(RemoteControls*)remoteControls;
-
 - (void)updateMetas:(CDVInvokedUrlCommand*)command;
-- (void)receiveRemoteEvent:(UIEvent *)receivedEvent;
+- (void)receiveRemoteEvent:(NSNotification *)notification;
 
 @end

--- a/src/ios/RemoteControls.m
+++ b/src/ios/RemoteControls.m
@@ -144,7 +144,7 @@ static RemoteControls *remoteControls = nil;
 
 -(void)dealloc {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
-   [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
 }
 
 @end

--- a/src/ios/RemoteControls.m
+++ b/src/ios/RemoteControls.m
@@ -16,6 +16,9 @@ static RemoteControls *remoteControls = nil;
 - (void)pluginInitialize
 {
     NSLog(@"RemoteControls plugin init.");
+    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receiveRemoteEvent:) name:@"receivedEvent" object:nil];
+
 }
 
 - (void)updateMetas:(CDVInvokedUrlCommand*)command
@@ -83,7 +86,9 @@ static RemoteControls *remoteControls = nil;
 }
 
 
-- (void)receiveRemoteEvent:(UIEvent *)receivedEvent {
+- (void)receiveRemoteEvent:(NSNotification *)notification {
+    
+    UIEvent * receivedEvent = notification.object;
 
     if (receivedEvent.type == UIEventTypeRemoteControl) {
 
@@ -126,23 +131,20 @@ static RemoteControls *remoteControls = nil;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options: 0 error: nil];
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         NSString *jsStatement = [NSString stringWithFormat:@"if(window.remoteControls)remoteControls.receiveRemoteEvent(%@);", jsonString];
+
+#ifdef __CORDOVA_4_0_0
+        [self.webViewEngine evaluateJavaScript:jsStatement completionHandler:nil];
+#else
         [self.webView stringByEvaluatingJavaScriptFromString:jsStatement];
-
+#endif
+        
     }
 }
 
-+(RemoteControls *)remoteControls
-{
-    //objects using shard instance are responsible for retain/release count
-    //retain count must remain 1 to stay in mem
 
-    if (!remoteControls)
-    {
-        remoteControls = [[RemoteControls alloc] init];
-    }
-
-    return remoteControls;
+-(void)dealloc {
+    [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
+   [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
 }
-
 
 @end


### PR DESCRIPTION
Added cordova iOS 4+ support.
Moved most parts of MainViewController.m to the plugin class so the
plugin user doesn’t have to add them.
Removed the RemoteControls singleton and used the NSNotificationCenter
to pass the event to the RemoteControls class.